### PR TITLE
fix: checkbox indicator on chrome, safari and firefox

### DIFF
--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -19,7 +19,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
         <ChakraCheckbox.Root ref={rootRef} {...rest}>
           <ChakraCheckbox.HiddenInput ref={ref} {...inputProps} />
           <ChakraCheckbox.Control>
-            {icon || <ChakraCheckbox.Indicator width={"fit-content"} />}
+            {icon || <ChakraCheckbox.Indicator width={"full"} />}
           </ChakraCheckbox.Control>
           {children != null && (
             <ChakraCheckbox.Label>{children}</ChakraCheckbox.Label>


### PR DESCRIPTION
Closes #15 